### PR TITLE
ADDED ADDITIONAL ENDPOINTS UP TO INACTIVECUSTOMERS

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -62,7 +62,7 @@ List<HoneyRaesAPI.Models.ServiceTicket> serviceTickets = new List<HoneyRaesAPI.M
         EmployeeId = 2,
         Description = "The Saleoomi needed a Cauldron",
         Emergency = true,
-        DateCompleted = DateTime.Now,
+        DateCompleted = new DateTime(2021, 1, 1),
     },
     new HoneyRaesAPI.Models.ServiceTicket()
     {
@@ -172,6 +172,7 @@ app.MapPut("/servicetickets/{id}/complete", (int id) =>
     return Results.Ok();
 });
 
+// EXTRA - SORTING BY EMERGENCIES
 app.MapGet("/servicetickets/emergencies", () =>
 {
     List<HoneyRaesAPI.Models.ServiceTicket> emergencyTicketsNotDone = serviceTickets.Where(st => st.Emergency == true && st.DateCompleted == null).ToList();
@@ -182,6 +183,7 @@ app.MapGet("/servicetickets/emergencies", () =>
     return Results.Ok(emergencyTicketsNotDone);
 });
 
+// EXTRA - SORTING BY UNASSIGNED
 app.MapGet("/servicetickets/unassigned", () =>
 {
     List<HoneyRaesAPI.Models.ServiceTicket> ticketsUnassigned = serviceTickets.Where(st => st.EmployeeId == null).ToList();
@@ -191,5 +193,24 @@ app.MapGet("/servicetickets/unassigned", () =>
     }
     return Results.Ok(ticketsUnassigned);
 });
+
+// EXTRA - SORTING BY INACTIVE CUSTOMERS
+app.MapGet("/customers/inactive", () =>
+{
+    List<HoneyRaesAPI.Models.ServiceTicket> completedTicktetsOlderThanAYear = new List<ServiceTicket>();
+    List<HoneyRaesAPI.Models.Customer> inactiveCustomers = new List<Customer>();
+    List<HoneyRaesAPI.Models.ServiceTicket> completedTickets = serviceTickets.Where(st => st.DateCompleted != null).ToList();
+    for (int i = 0; i < completedTickets.Count; i++)
+    {
+        TimeSpan? ticketAge = DateTime.Now - completedTickets[i].DateCompleted;
+        if (ticketAge?.Days >= 365)
+        {
+            completedTicktetsOlderThanAYear.Add(completedTickets[i]); 
+        }
+
+    }
+    return Results.Ok(inactiveCustomers);
+});
+
 
 app.Run();

--- a/Program.cs
+++ b/Program.cs
@@ -172,4 +172,14 @@ app.MapPut("/servicetickets/{id}/complete", (int id) =>
     return Results.Ok();
 });
 
+app.MapGet("/servicetickets/emergencies", () =>
+{
+    List<HoneyRaesAPI.Models.ServiceTicket> emergencyTicketsNotDone = serviceTickets.Where(st => st.Emergency == true && st.DateCompleted == null).ToList();
+    if (emergencyTicketsNotDone.Count == 0)
+    {
+        return Results.NotFound();
+    }
+    return Results.Ok(emergencyTicketsNotDone);
+});
+
 app.Run();

--- a/Program.cs
+++ b/Program.cs
@@ -70,8 +70,8 @@ List<HoneyRaesAPI.Models.ServiceTicket> serviceTickets = new List<HoneyRaesAPI.M
         CustomerId = 3,
         EmployeeId = 3,
         Description = "The Salogna needed a Cauldron",
-        Emergency = false,
-        DateCompleted = DateTime.Now,
+        Emergency = true,
+        DateCompleted = null,
     },
 
 };
@@ -158,6 +158,17 @@ app.MapPut("/servicetickets/{id}", (int id, ServiceTicket updatedServiceTicket) 
         return Results.NotFound();
     }
     ticketToUpdate.EmployeeId = updatedServiceTicket.EmployeeId;
+    return Results.Ok();
+});
+
+app.MapPut("/servicetickets/{id}/complete", (int id) =>
+{
+    ServiceTicket ticketToUpdate = serviceTickets.FirstOrDefault(st => st.Id == id);
+    if (ticketToUpdate == null)
+    {
+        return Results.NotFound();
+    }
+    ticketToUpdate.DateCompleted = DateTime.Now;
     return Results.Ok();
 });
 

--- a/Program.cs
+++ b/Program.cs
@@ -53,7 +53,7 @@ List<HoneyRaesAPI.Models.ServiceTicket> serviceTickets = new List<HoneyRaesAPI.M
         EmployeeId = 1,
         Description = "The Salem needed a Cauldron",
         Emergency = false,
-        DateCompleted = DateTime.Now,
+        DateCompleted = new DateTime(2021, 1, 1),
     },
         new HoneyRaesAPI.Models.ServiceTicket()
     {
@@ -209,6 +209,19 @@ app.MapGet("/customers/inactive", () =>
         }
 
     }
+
+    for (int i = 0; i < customers.Count; i++)
+    {
+        for (int j = 0; j < completedTicktetsOlderThanAYear.Count; j++)
+        {
+            if (completedTicktetsOlderThanAYear[j].CustomerId == customers[i].Id)
+            {
+                inactiveCustomers.Add(customers[i]);
+            }
+        }
+    
+    }
+
     return Results.Ok(inactiveCustomers);
 });
 

--- a/Program.cs
+++ b/Program.cs
@@ -68,7 +68,7 @@ List<HoneyRaesAPI.Models.ServiceTicket> serviceTickets = new List<HoneyRaesAPI.M
     {
         Id = 3,
         CustomerId = 3,
-        EmployeeId = 3,
+        EmployeeId = null,
         Description = "The Salogna needed a Cauldron",
         Emergency = true,
         DateCompleted = null,
@@ -180,6 +180,16 @@ app.MapGet("/servicetickets/emergencies", () =>
         return Results.NotFound();
     }
     return Results.Ok(emergencyTicketsNotDone);
+});
+
+app.MapGet("/servicetickets/unassigned", () =>
+{
+    List<HoneyRaesAPI.Models.ServiceTicket> ticketsUnassigned = serviceTickets.Where(st => st.EmployeeId == null).ToList();
+    if (ticketsUnassigned.Count == 0)
+    {
+        return Results.NotFound();
+    }
+    return Results.Ok(ticketsUnassigned);
 });
 
 app.Run();


### PR DESCRIPTION
- Added following endpoints:
1. Emergencies
Create an endpoint to return all of the service tickets that are incomplete and are emergencies

2. Unassigned
Create an endpoint to return all currently unassigned service tickets

3. Inactive Customers
Create an endpoint to return all of the customers that haven't had a service ticket closed for them in over a year (refer to the explorer chapter in Book 1 on calculating DateTimes).